### PR TITLE
Reformat loaded data

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,16 @@ version = "0.2.0"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
 Artifacts = "1"
+Compat = "4.3"
 JSON3 = "1"
+OrderedCollections = "1"
 ZipFile = "0.10"
 julia = "1.3"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,20 +1,18 @@
 name = "PosteriorDB"
 uuid = "1c4bc282-d2f5-44f9-b6d1-8c4424a23ad4"
 authors = ["Seth Axen <seth@sethaxen.com> and contributors"]
-version = "0.3.0"
+version = "0.3.0-DEV"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
-OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
 Artifacts = "1"
 Compat = "4.3"
 JSON3 = "1"
-OrderedCollections = "1"
 ZipFile = "0.10"
 julia = "1.3"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PosteriorDB"
 uuid = "1c4bc282-d2f5-44f9-b6d1-8c4424a23ad4"
 authors = ["Seth Axen <seth@sethaxen.com> and contributors"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
 Artifacts = "1"
-Compat = "4.3"
+Compat = "3, 4"
 JSON3 = "1"
 ZipFile = "0.10"
 julia = "1.3"

--- a/src/PosteriorDB.jl
+++ b/src/PosteriorDB.jl
@@ -9,7 +9,6 @@ module PosteriorDB
 
 using JSON3, ZipFile
 using Artifacts: @artifact_str
-using OrderedCollections: OrderedDict
 using Compat: stack
 
 const POSTERIOR_DB_ARTIFACT_PATH = artifact"posteriordb"

--- a/src/PosteriorDB.jl
+++ b/src/PosteriorDB.jl
@@ -9,6 +9,7 @@ module PosteriorDB
 
 using JSON3, ZipFile
 using Artifacts: @artifact_str
+using OrderedCollections: OrderedDict
 using Compat: stack
 
 const POSTERIOR_DB_ARTIFACT_PATH = artifact"posteriordb"

--- a/src/PosteriorDB.jl
+++ b/src/PosteriorDB.jl
@@ -9,6 +9,7 @@ module PosteriorDB
 
 using JSON3, ZipFile
 using Artifacts: @artifact_str
+using Compat: stack
 
 const POSTERIOR_DB_ARTIFACT_PATH = artifact"posteriordb"
 const POSTERIOR_DB_DEFAULT_PATH = joinpath(

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -13,9 +13,9 @@ end
 function Base.show(io::IO, d::Dataset)
     print(io, "Dataset: ", name(d))
     i = info(d)
-    if haskey(i, :title)
+    if haskey(i, "title")
         println(io)
-        print(io, "Title: ", i.title)
+        print(io, "Title: ", i["title"])
     end
     return nothing
 end
@@ -37,6 +37,6 @@ info(d::Dataset) = load_json(data_info_path(database(d), name(d)))
 Load and return the data for `dataset`.
 """
 function load_values(d::Dataset)
-    path = joinpath(database(d).path, "$(info(d).data_file).zip")
+    path = joinpath(database(d).path, "$(info(d)["data_file"]).zip")
     return load_zipped_json(path)
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -13,13 +13,15 @@ end
 function Base.show(io::IO, m::Model)
     print(io, "Model: ", name(m))
     i = info(m)
-    if haskey(i, :title)
+    if haskey(i, "title")
         println(io)
-        print(io, "Title: ", i.title)
+        print(io, "Title: ", i["title"])
     end
     if haskey(i, :model_implementations)
         println(io)
-        print(io, "Implementations: ", join(collect(keys(i.model_implementations)), ", "))
+        print(
+            io, "Implementations: ", join(collect(keys(i["model_implementations"])), ", ")
+        )
     end
     return nothing
 end
@@ -40,7 +42,9 @@ info(m::Model) = load_json(model_info_path(database(m), name(m)))
 
 Return the names of frameworks with code for the `model`.
 """
-implementation_names(m::Model) = map(String, collect(keys(info(m).model_implementations)))
+function implementation_names(m::Model)
+    return map(String, collect(keys(info(m)["model_implementations"])))
+end
 
 """
     implementation(model::Model, framework::String) -> String
@@ -48,6 +52,8 @@ implementation_names(m::Model) = map(String, collect(keys(info(m).model_implemen
 Return the code for the implementation of `model` in the `framework`.
 """
 function implementation(m::Model, framework::String)
-    path = joinpath(database(m).path, info(m).model_implementations[framework].model_code)
+    path = joinpath(
+        database(m).path, info(m)["model_implementations"][framework]["model_code"]
+    )
     return read(path, String)
 end

--- a/src/posterior.jl
+++ b/src/posterior.jl
@@ -28,14 +28,14 @@ info(p::Posterior) = load_json(posterior_info_path(database(p), name(p)))
 
 Return the model entry of `posterior`.
 """
-model(p::Posterior) = model(database(p), info(p).model_name)
+model(p::Posterior) = model(database(p), info(p)["model_name"])
 
 """
     dataset(posterior::Posterior) -> Dataset
 
 Return the dataset entry of `posterior`.
 """
-dataset(p::Posterior) = dataset(database(p), info(p).data_name)
+dataset(p::Posterior) = dataset(database(p), info(p)["data_name"])
 
 """
     reference_posterior(posterior::Posterior) -> Union{Nothing,ReferencePosterior}
@@ -45,7 +45,7 @@ Return the reference posterior entry of `posterior`.
 If no reference posterior is available, `nothing` is returned.
 """
 function reference_posterior(p::Posterior)
-    ref_name = info(p).reference_posterior_name
+    ref_name = info(p)["reference_posterior_name"]
     ref_name === nothing && return nothing
     return reference_posterior(database(p), ref_name)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,4 @@
-load_json(path) = format_json_data(open(JSON3.read, path, "r"))
+load_json(path) = format_json_data(copy(open(JSON3.read, path, "r")))
 
 function load_zipped_json(path)
     reader = ZipFile.Reader(path)
@@ -11,7 +11,7 @@ function load_zipped_json(path)
             ),
         )
     end
-    contents = JSON3.read(first(files))
+    contents = copy(JSON3.read(first(files)))
     close(reader)
     return format_json_data(contents)
 end
@@ -27,15 +27,12 @@ function format_json_data(data::AbstractDict)
 end
 format_json_data(data::AbstractVector{<:AbstractDict}) = map(format_json_data, data)
 function format_json_data(data::AbstractVector)
-    arr = recursive_stack(_asarray, data)
+    arr = recursive_stack(data)
     dims = ntuple(identity, ndims(arr))
     arr_perm = permutedims(arr, reverse(dims))
     S = Base.promote_union(eltype(arr_perm))
     return convert(Array{S}, arr_perm)
 end
-
-_asarray(data::Array) = data
-_asarray(data::JSON3.Array) = copy(data)
 
 """
     recursive_stack(x::AbstractArray)
@@ -43,5 +40,5 @@ _asarray(data::JSON3.Array) = copy(data)
 If `x` is an array of arrays, recursively stack into a single array whose dimensions are
 ordered with dimensions of the innermost container first and outermost last.
 """
-recursive_stack(f, x) = x
-recursive_stack(f, x::AbstractArray{<:AbstractArray}) = recursive_stack(f, stack(f, x))
+recursive_stack(x) = x
+recursive_stack(x::AbstractArray{<:AbstractArray}) = recursive_stack(stack(x))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,4 @@
-load_json(path) = open(JSON3.read, path, "r")
+load_json(path) = format_json_data(open(JSON3.read, path, "r"))
 
 function load_zipped_json(path)
     reader = ZipFile.Reader(path)
@@ -13,7 +13,7 @@ function load_zipped_json(path)
     end
     contents = JSON3.read(first(files))
     close(reader)
-    return contents
+    return format_json_data(contents)
 end
 
 function filenames_no_extension(path, ext; kwargs...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -21,6 +21,22 @@ function filenames_no_extension(path, ext; kwargs...)
     return map(fn -> fn[1:(end - length(ext))], filenames)
 end
 
+format_json_data(data) = data
+function format_json_data(data::AbstractDict)
+    return OrderedDict{String,Any}(string(k) => format_json_data(v) for (k, v) in data)
+end
+format_json_data(data::AbstractVector{<:AbstractDict}) = map(format_json_data, data)
+function format_json_data(data::AbstractVector)
+    arr = recursive_stack(_asarray, data)
+    dims = ntuple(identity, ndims(arr))
+    arr_perm = permutedims(arr, reverse(dims))
+    S = Base.promote_union(eltype(arr_perm))
+    return convert(Array{S}, arr_perm)
+end
+
+_asarray(data::Array) = data
+_asarray(data::JSON3.Array) = copy(data)
+
 """
     recursive_stack(x::AbstractArray)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,4 @@
-load_json(path) = format_json_data(copy(open(JSON3.read, path, "r")))
+load_json(path) = format_json_data(open(JSON3.read, path, "r"))
 
 function load_zipped_json(path)
     reader = ZipFile.Reader(path)
@@ -11,7 +11,7 @@ function load_zipped_json(path)
             ),
         )
     end
-    contents = copy(JSON3.read(first(files)))
+    contents = JSON3.read(first(files))
     close(reader)
     return format_json_data(contents)
 end
@@ -27,12 +27,15 @@ function format_json_data(data::AbstractDict)
 end
 format_json_data(data::AbstractVector{<:AbstractDict}) = map(format_json_data, data)
 function format_json_data(data::AbstractVector)
-    arr = recursive_stack(data)
+    arr = recursive_stack(_asarray, data)
     dims = ntuple(identity, ndims(arr))
     arr_perm = permutedims(arr, reverse(dims))
     S = Base.promote_union(eltype(arr_perm))
     return convert(Array{S}, arr_perm)
 end
+
+_asarray(data::Array) = data
+_asarray(data::JSON3.Array) = copy(data)
 
 """
     recursive_stack(x::AbstractArray)
@@ -40,5 +43,5 @@ end
 If `x` is an array of arrays, recursively stack into a single array whose dimensions are
 ordered with dimensions of the innermost container first and outermost last.
 """
-recursive_stack(x) = x
-recursive_stack(x::AbstractArray{<:AbstractArray}) = recursive_stack(stack(x))
+recursive_stack(f, x) = x
+recursive_stack(f, x::AbstractArray{<:AbstractArray}) = recursive_stack(f, stack(f, x))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -23,7 +23,7 @@ end
 
 format_json_data(data) = data
 function format_json_data(data::AbstractDict)
-    return OrderedDict{String,Any}(string(k) => format_json_data(v) for (k, v) in data)
+    return Dict{String,Any}(string(k) => format_json_data(v) for (k, v) in data)
 end
 format_json_data(data::AbstractVector{<:AbstractDict}) = map(format_json_data, data)
 function format_json_data(data::AbstractVector)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -20,3 +20,12 @@ function filenames_no_extension(path, ext; kwargs...)
     filenames = filter!(Base.Fix2(endswith, ext), readdir(path; kwargs...))
     return map(fn -> fn[1:(end - length(ext))], filenames)
 end
+
+"""
+    recursive_stack(x::AbstractArray)
+
+If `x` is an array of arrays, recursively stack into a single array whose dimensions are
+ordered with dimensions of the innermost container first and outermost last.
+"""
+recursive_stack(f, x) = x
+recursive_stack(f, x::AbstractArray{<:AbstractArray}) = recursive_stack(f, stack(f, x))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,7 +68,7 @@ using Test
             @test post isa Posterior
             @test name(post) == n
             @test database(post) == pdb
-            @test info(post) isa AbstractDict
+            @test info(post) isa OrderedDict{String}
             mod = model(post)
             @test mod isa Model
             @test database(mod) === pdb
@@ -82,7 +82,7 @@ using Test
             if ref !== nothing
                 @test name(ref) isa String
                 @test database(ref) === pdb
-                @test info(ref) isa AbstractDict
+                @test info(ref) isa OrderedDict{String}
                 load_values(ref)
             end
         end
@@ -97,7 +97,7 @@ using Test
             @test mod isa Model
             @test name(mod) == n
             @test database(mod) == pdb
-            @test info(mod) isa AbstractDict
+            @test info(mod) isa OrderedDict{String}
             ppls = implementation_names(mod)
             @test ppls isa Vector{String}
             @test !isempty(ppls)
@@ -117,8 +117,8 @@ using Test
             @test data isa Dataset
             @test name(data) == n
             @test database(data) == pdb
-            @test info(data) isa AbstractDict
-            @test load_values(data) isa AbstractDict
+            @test info(data) isa OrderedDict{String}
+            @test load_values(data) isa OrderedDict{String}
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,12 +5,11 @@ using Test
 @testset "PosteriorDB.jl" begin
     @testset "utils" begin
         @testset "recursive_stack" begin
-            @test PosteriorDB.recursive_stack(identity, [1, 2]) == [1, 2]
-            @test PosteriorDB.recursive_stack(identity, [[1, 2]]) == permutedims([1 2])
-            @test PosteriorDB.recursive_stack(identity, [[1, 2], [3, 4]]) ==
-                reshape(1:4, 2, 2)
-            @test PosteriorDB.recursive_stack(identity, 1) === 1
-            @test PosteriorDB.recursive_stack(identity, 1:5) == 1:5
+            @test PosteriorDB.recursive_stack([1, 2]) == [1, 2]
+            @test PosteriorDB.recursive_stack([[1, 2]]) == permutedims([1 2])
+            @test PosteriorDB.recursive_stack([[1, 2], [3, 4]]) == reshape(1:4, 2, 2)
+            @test PosteriorDB.recursive_stack(1) === 1
+            @test PosteriorDB.recursive_stack(1:5) == 1:5
         end
 
         @testset "format_json_data" begin
@@ -33,7 +32,7 @@ using Test
                 ),
             )
             s = JSON3.write(sample_dict)
-            d = JSON3.read(s)
+            d = copy(JSON3.read(s))
             df = PosteriorDB.format_json_data(d)
             @test df isa Dict{String,Any}
             for (k, v) in df

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,11 +5,12 @@ using Test
 @testset "PosteriorDB.jl" begin
     @testset "utils" begin
         @testset "recursive_stack" begin
-            @test PosteriorDB.recursive_stack([1, 2]) == [1, 2]
-            @test PosteriorDB.recursive_stack([[1, 2]]) == permutedims([1 2])
-            @test PosteriorDB.recursive_stack([[1, 2], [3, 4]]) == reshape(1:4, 2, 2)
-            @test PosteriorDB.recursive_stack(1) === 1
-            @test PosteriorDB.recursive_stack(1:5) == 1:5
+            @test PosteriorDB.recursive_stack(identity, [1, 2]) == [1, 2]
+            @test PosteriorDB.recursive_stack(identity, [[1, 2]]) == permutedims([1 2])
+            @test PosteriorDB.recursive_stack(identity, [[1, 2], [3, 4]]) ==
+                reshape(1:4, 2, 2)
+            @test PosteriorDB.recursive_stack(identity, 1) === 1
+            @test PosteriorDB.recursive_stack(identity, 1:5) == 1:5
         end
 
         @testset "format_json_data" begin
@@ -32,7 +33,7 @@ using Test
                 ),
             )
             s = JSON3.write(sample_dict)
-            d = copy(JSON3.read(s))
+            d = JSON3.read(s)
             df = PosteriorDB.format_json_data(d)
             @test df isa Dict{String,Any}
             for (k, v) in df

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,17 @@ using PosteriorDB
 using Test
 
 @testset "PosteriorDB.jl" begin
+    @testset "utils" begin
+        @testset "recursive_stack" begin
+            @test PosteriorDB.recursive_stack(identity, [1, 2]) == [1, 2]
+            @test PosteriorDB.recursive_stack(identity, [[1, 2]]) == permutedims([1 2])
+            @test PosteriorDB.recursive_stack(identity, [[1, 2], [3, 4]]) ==
+                reshape(1:4, 2, 2)
+            @test PosteriorDB.recursive_stack(identity, 1) === 1
+            @test PosteriorDB.recursive_stack(identity, 1:5) == 1:5
+        end
+    end
+
     pdb = database()
 
     @testset "PosteriorDatabase" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using PosteriorDB
 using JSON3
-using OrderedCollections
 using Test
 
 @testset "PosteriorDB.jl" begin
@@ -29,23 +28,23 @@ using Test
             sample_dict = merge(
                 sample_dict,
                 Dict(
-                    "OrderedDict{String,Any}" => sample_dict,
-                    "Vector{OrderedDict{String,Any}}" => [sample_dict],
+                    "Dict{String,Any}" => sample_dict,
+                    "Vector{Dict{String,Any}}" => [sample_dict],
                 ),
             )
             s = JSON3.write(sample_dict)
             d = JSON3.read(s)
             df = PosteriorDB.format_json_data(d)
-            @test df isa OrderedDict{String,Any}
+            @test df isa Dict{String,Any}
             for (k, v) in df
                 @test v isa eval(Meta.parse(k))
                 v isa AbstractArray{<:Real} && @test size(v) == sz[1:ndims(v)]
             end
-            for (k, v) in df["OrderedDict{String,Any}"]
+            for (k, v) in df["Dict{String,Any}"]
                 @test v isa eval(Meta.parse(k))
                 v isa AbstractArray{<:Real} && @test size(v) == sz[1:ndims(v)]
             end
-            for (k, v) in df["Vector{OrderedDict{String,Any}}"][1]
+            for (k, v) in df["Vector{Dict{String,Any}}"][1]
                 @test v isa eval(Meta.parse(k))
                 v isa AbstractArray{<:Real} && @test size(v) == sz[1:ndims(v)]
             end
@@ -68,7 +67,7 @@ using Test
             @test post isa Posterior
             @test name(post) == n
             @test database(post) == pdb
-            @test info(post) isa OrderedDict{String}
+            @test info(post) isa Dict{String}
             mod = model(post)
             @test mod isa Model
             @test database(mod) === pdb
@@ -82,7 +81,7 @@ using Test
             if ref !== nothing
                 @test name(ref) isa String
                 @test database(ref) === pdb
-                @test info(ref) isa OrderedDict{String}
+                @test info(ref) isa Dict{String}
                 load_values(ref)
             end
         end
@@ -97,7 +96,7 @@ using Test
             @test mod isa Model
             @test name(mod) == n
             @test database(mod) == pdb
-            @test info(mod) isa OrderedDict{String}
+            @test info(mod) isa Dict{String}
             ppls = implementation_names(mod)
             @test ppls isa Vector{String}
             @test !isempty(ppls)
@@ -117,8 +116,8 @@ using Test
             @test data isa Dataset
             @test name(data) == n
             @test database(data) == pdb
-            @test info(data) isa OrderedDict{String}
-            @test load_values(data) isa OrderedDict{String}
+            @test info(data) isa Dict{String}
+            @test load_values(data) isa Dict{String}
         end
     end
 end


### PR DESCRIPTION
This PR fixes #1 with the following changes:
- All loaded values are returned as `Dict{String,Any}`s whose array values are `Array`s.
- Vectors of vectors are interpreted as vectors of row vectors and formatted as matrices
- Vectors of vectors of vectors are interpreted and formatted as multidimensonal arrays

Data formatted this way can be used directly in StanSample.jl