### PR TITLE
Support old Julia versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
         if: matrix.version == '1.0'
       - name: Set POSTERIOR_DB_PATH environmental variable
         run: |
-          echo "POSTERIOR_DB_PATH="$GITHUB_WORKSPACE/posteriordb/posterior_database" >> $GITHUB_ENV
+          echo "POSTERIOR_DB_PATH=$GITHUB_WORKSPACE/posteriordb/posterior_database" >> $GITHUB_ENV
         if: matrix.version == '1.0'
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
+          - '1.0'  # minimum supported version
+          - '1.3'  # minimum version with default database
           - '1'
           - 'nightly'
         os:
@@ -33,6 +34,16 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
+      - name: Clone posteriordb
+        uses: actions/checkout@v2
+        with:
+          repository: stan-dev/posteriordb
+          path: 'posteriordb'
+        if: matrix.version == '1.0'
+      - name: Set POSTERIOR_DB_PATH environmental variable
+        run: |
+          echo "POSTERIOR_DB_PATH="$GITHUB_WORKSPACE/posteriordb/posterior_database" >> $GITHUB_ENV
+        if: matrix.version == '1.0'
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v2

--- a/Project.toml
+++ b/Project.toml
@@ -11,10 +11,10 @@ ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
 Artifacts = "1"
-Compat = "3, 4"
+Compat = "3"
 JSON3 = "1"
-ZipFile = "0.10"
-julia = "1.3"
+ZipFile = "0.8, 0.9, 0.10"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PosteriorDB"
 uuid = "1c4bc282-d2f5-44f9-b6d1-8c4424a23ad4"
 authors = ["Seth Axen <seth@sethaxen.com> and contributors"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/PosteriorDB.jl
+++ b/src/PosteriorDB.jl
@@ -8,13 +8,8 @@ See https://github.com/stan-dev/posteriordb for more information.
 module PosteriorDB
 
 using JSON3, ZipFile
-using Artifacts: @artifact_str
 using Compat: stack
-
-const POSTERIOR_DB_ARTIFACT_PATH = artifact"posteriordb"
-const POSTERIOR_DB_DEFAULT_PATH = joinpath(
-    POSTERIOR_DB_ARTIFACT_PATH, readdir(POSTERIOR_DB_ARTIFACT_PATH)[1], "posterior_database"
-)
+VERSION ≥ v"1.3" && using Artifacts
 
 include("utils.jl")
 include("common.jl")

--- a/src/common.jl
+++ b/src/common.jl
@@ -6,7 +6,7 @@ Return the database containing `obj`.
 `obj` can be a `Posterior`, `Model`, `AbstractImplementation`, `Dataset`, or
 `ReferencePosterior`.
 """
-function database end
+database(::Any)
 
 """
     name(obj) -> String
@@ -15,7 +15,7 @@ Return the name of `obj`.
 
 `obj` can be a `Posterior`, `Model`, `Dataset`, or `ReferencePosterior`.
 """
-function name end
+name(::Any)
 
 """
     info(obj) -> AbstractDict
@@ -24,4 +24,4 @@ Return the info dictionary for `obj`.
 
 `obj` can be a `Posterior`, `Model`, `Dataset`, or `ReferencePosterior`.
 """
-function info end
+info(::Any)

--- a/src/posterior_database.jl
+++ b/src/posterior_database.jl
@@ -16,8 +16,25 @@ Return a pointer to the [`PosteriorDatabase`](@ref) stored at `path`.
 
 If `path` is not given, the default posterior database downloaded from a GitHub release is
 used.
+
+!!! note
+    Julia 1.3 or greater is required to use the default posterior database with `database()`.
 """
-database(path::String=POSTERIOR_DB_DEFAULT_PATH) = PosteriorDatabase(path)
+database
+database(path::String) = PosteriorDatabase(path)
+
+@static if VERSION ≥ v"1.3"
+    function database()
+        artifact_path = artifact"posteriordb"
+        path = joinpath(artifact_path, readdir(artifact_path)[1], "posterior_database")
+        return database(path)
+    end
+else
+    function database()
+        @error "On Julia versions < 1.3, the path to the posterior database must be provided. A copy can be downloaded from https://github.com/stan-dev/posteriordb."
+        return throw(MethodError(database, ()))
+    end
+end
 
 Base.show(io::IO, ::PosteriorDatabase) = print(io, "PosteriorDatabase(...)")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using PosteriorDB
 using JSON3
 using Test
 
-POSTERIOR_DB_PATH = get(ENV, "POSTERIOR_DB_PATH", nothing)
+POSTERIOR_DB_PATH = get(ENV, "POSTERIOR_DB_PATH", "")
 
 @testset "PosteriorDB.jl" begin
     @testset "utils" begin
@@ -53,7 +53,7 @@ POSTERIOR_DB_PATH = get(ENV, "POSTERIOR_DB_PATH", nothing)
         end
     end
 
-    if POSTERIOR_DB_PATH === nothing
+    if isempty(POSTERIOR_DB_PATH)
         pdb = database()
     else
         pdb = database(POSTERIOR_DB_PATH)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@ using PosteriorDB
 using JSON3
 using Test
 
+POSTERIOR_DB_PATH = get(ENV, "POSTERIOR_DB_PATH", nothing)
+
 @testset "PosteriorDB.jl" begin
     @testset "utils" begin
         @testset "recursive_stack" begin
@@ -51,7 +53,11 @@ using Test
         end
     end
 
-    pdb = database()
+    if POSTERIOR_DB_PATH === nothing
+        pdb = database()
+    else
+        pdb = database(POSTERIOR_DB_PATH)
+    end
 
     @testset "PosteriorDatabase" begin
         @test pdb isa PosteriorDatabase

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,6 +62,7 @@ POSTERIOR_DB_PATH = get(ENV, "POSTERIOR_DB_PATH", "")
     @testset "PosteriorDatabase" begin
         @test pdb isa PosteriorDatabase
         @test isdir(path(pdb))
+        VERSION < v"1.3" && @test_throws MethodError database()
     end
 
     @testset "posterior" begin


### PR DESCRIPTION
This PR lowers the Julia version lower bound to 1.0. It does so by only using the Artifacts system for v1.3 and newer, for which the system is available. Otherwise, the user is expected to download posteriordb themselves.