### PR TITLE
Restore support for Compat v4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
 Artifacts = "1"
-Compat = "3"
+Compat = "3, 4"
 JSON3 = "1"
 ZipFile = "0.8, 0.9, 0.10"
 julia = "1"


### PR DESCRIPTION
Reverts a reduction in the compat for Compat mistakenly introduced in #9 