### PR TITLE
Supporting loading data and draws as Strings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PosteriorDB"
 uuid = "1c4bc282-d2f5-44f9-b6d1-8c4424a23ad4"
 authors = ["Seth Axen <seth@sethaxen.com> and contributors"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -84,6 +84,7 @@ We can access information about the dataset and load it with [`load`](@ref).
 info(data)
 path(data)
 load(data)
+load(data, String)
 ```
 
 Lastly, we can access gold standard posterior draws with [`reference_posterior`](@ref) and [`load`](@ref).
@@ -94,4 +95,5 @@ info(ref)
 path(ref)
 using DataFrames
 DataFrame(load(ref))
+load(ref, String)
 ```

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -42,5 +42,10 @@ path(d::Dataset) = joinpath(path(database(d)), "$(info(d)["data_file"]).zip")
     load(dataset::Dataset) -> Dict{String,Any}
 
 Load and return the data for `dataset`.
+
+    load(dataset::Dataset, String) -> String
+
+Return the data for `dataset` as an unparsed JSON string.
 """
 load(d::Dataset) = load_zipped_json(path(d))
+load(d::Dataset, ::Type{String}) = load_zipped_string(path(d))

--- a/src/reference_posterior.jl
+++ b/src/reference_posterior.jl
@@ -34,5 +34,10 @@ path(r::ReferencePosterior) = reference_posterior_draws_path(database(r), name(r
     load(rp::ReferencePosterior) -> Vector{Dict{String,Any}}
 
 Load and return the reference draws for the reference posterior `rp`.
+
+    load(rp::ReferencePosterior, String) -> String
+
+Return the reference draws as an unparsed JSON string.
 """
 load(r::ReferencePosterior) = load_zipped_json(path(r))
+load(r::ReferencePosterior, ::Type{String}) = load_zipped_string(path(r))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,6 @@
 load_json(path) = format_json_data(open(JSON3.read, path, "r"))
 
-function load_zipped_json(path)
+function load_zipped_file(f, path)
     reader = ZipFile.Reader(path)
     files = reader.files
     nfiles = length(files)
@@ -11,10 +11,14 @@ function load_zipped_json(path)
             ),
         )
     end
-    contents = JSON3.read(first(files))
+    result = f(first(files))
     close(reader)
-    return format_json_data(contents)
+    return result
 end
+
+load_zipped_json(path) = load_zipped_file(format_json_data ∘ JSON3.read, path)
+
+load_zipped_string(path) = load_zipped_file(Base.Fix2(read, String), path)
 
 function filenames_no_extension(path, ext; kwargs...)
     filenames = filter!(Base.Fix2(endswith, ext), readdir(path; kwargs...))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,7 +90,8 @@ POSTERIOR_DB_PATH = get(ENV, "POSTERIOR_DB_PATH", "")
                 @test database(ref) === pdb
                 @test info(ref) isa Dict{String}
                 @test isfile(path(ref))
-                load(ref)
+                @test load(ref) isa Vector{<:Dict{String}}
+                @test load(ref, String) isa String
             end
         end
     end
@@ -129,6 +130,8 @@ POSTERIOR_DB_PATH = get(ENV, "POSTERIOR_DB_PATH", "")
             @test info(data) isa Dict{String}
             @test isfile(path(data))
             @test load(data) isa Dict{String}
+            @test load(data, String) isa String
+            @test PosteriorDB.format_json_data(JSON3.read(load(data, String))) == load(data)
         end
     end
 end


### PR DESCRIPTION
Sometimes it may be useful for the user to retrieve the JSON string containing data or reference posterior draws. One use case is when they want to use a different JSON parser than JSON3.jl. Another example is BridgeStan, which expects the data is provided as a path to a non-zipped file or as a JSON string.

This PR adds a second `String` argument for `load` for both of these data structures to support these use cases.