### PR TITLE
Return OrderedDict instead of Dict

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PosteriorDB"
 uuid = "1c4bc282-d2f5-44f9-b6d1-8c4424a23ad4"
 authors = ["Seth Axen <seth@sethaxen.com> and contributors"]
-version = "0.3.2"
+version = "0.4.0"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/Project.toml
+++ b/Project.toml
@@ -7,12 +7,14 @@ version = "0.3.2"
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
 Artifacts = "1"
 Compat = "3, 4"
 JSON3 = "1"
+OrderedCollections = "1"
 ZipFile = "0.8, 0.9, 0.10"
 julia = "1"
 

--- a/src/PosteriorDB.jl
+++ b/src/PosteriorDB.jl
@@ -8,6 +8,7 @@ See https://github.com/stan-dev/posteriordb for more information.
 module PosteriorDB
 
 using JSON3, ZipFile
+using OrderedCollections: OrderedDict
 using Compat: stack
 VERSION ≥ v"1.3" && using Artifacts
 

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -39,7 +39,7 @@ Absolute path to the file containing the model `dataset`.
 path(d::Dataset) = joinpath(path(database(d)), "$(info(d)["data_file"]).zip")
 
 """
-    load(dataset::Dataset) -> Dict{String,Any}
+    load(dataset::Dataset) -> OrderedDict{String,Any}
 
 Load and return the data for `dataset`.
 

--- a/src/reference_posterior.jl
+++ b/src/reference_posterior.jl
@@ -31,7 +31,7 @@ Return the path to the file storing the reference draws for the reference poster
 path(r::ReferencePosterior) = reference_posterior_draws_path(database(r), name(r))
 
 """
-    load(rp::ReferencePosterior) -> Vector{Dict{String,Any}}
+    load(rp::ReferencePosterior) -> Vector{OrderedDict{String,Any}}
 
 Load and return the reference draws for the reference posterior `rp`.
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -27,7 +27,7 @@ end
 
 format_json_data(data) = data
 function format_json_data(data::AbstractDict)
-    return Dict{String,Any}(string(k) => format_json_data(v) for (k, v) in data)
+    return OrderedDict{String,Any}(string(k) => format_json_data(v) for (k, v) in data)
 end
 format_json_data(data::AbstractVector{<:AbstractDict}) = map(format_json_data, data)
 function format_json_data(data::AbstractVector)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using PosteriorDB
 using JSON3
+using OrderedCollections: OrderedDict
 using Test
 
 POSTERIOR_DB_PATH = get(ENV, "POSTERIOR_DB_PATH", "")
@@ -30,23 +31,23 @@ POSTERIOR_DB_PATH = get(ENV, "POSTERIOR_DB_PATH", "")
             sample_dict = merge(
                 sample_dict,
                 Dict(
-                    "Dict{String,Any}" => sample_dict,
-                    "Vector{Dict{String,Any}}" => [sample_dict],
+                    "OrderedDict{String,Any}" => sample_dict,
+                    "Vector{OrderedDict{String,Any}}" => [sample_dict],
                 ),
             )
             s = JSON3.write(sample_dict)
             d = JSON3.read(s)
             df = PosteriorDB.format_json_data(d)
-            @test df isa Dict{String,Any}
+            @test df isa OrderedDict{String,Any}
             for (k, v) in df
                 @test v isa eval(Meta.parse(k))
                 v isa AbstractArray{<:Real} && @test size(v) == sz[1:ndims(v)]
             end
-            for (k, v) in df["Dict{String,Any}"]
+            for (k, v) in df["OrderedDict{String,Any}"]
                 @test v isa eval(Meta.parse(k))
                 v isa AbstractArray{<:Real} && @test size(v) == sz[1:ndims(v)]
             end
-            for (k, v) in df["Vector{Dict{String,Any}}"][1]
+            for (k, v) in df["Vector{OrderedDict{String,Any}}"][1]
                 @test v isa eval(Meta.parse(k))
                 v isa AbstractArray{<:Real} && @test size(v) == sz[1:ndims(v)]
             end
@@ -74,7 +75,7 @@ POSTERIOR_DB_PATH = get(ENV, "POSTERIOR_DB_PATH", "")
             @test post isa Posterior
             @test name(post) == n
             @test database(post) == pdb
-            @test info(post) isa Dict{String}
+            @test info(post) isa OrderedDict{String}
             mod = model(post)
             @test mod isa Model
             @test database(mod) === pdb
@@ -88,9 +89,9 @@ POSTERIOR_DB_PATH = get(ENV, "POSTERIOR_DB_PATH", "")
             if ref !== nothing
                 @test name(ref) isa String
                 @test database(ref) === pdb
-                @test info(ref) isa Dict{String}
+                @test info(ref) isa OrderedDict{String}
                 @test isfile(path(ref))
-                @test load(ref) isa Vector{<:Dict{String}}
+                @test load(ref) isa Vector{<:OrderedDict{String}}
                 @test load(ref, String) isa String
             end
         end
@@ -105,7 +106,7 @@ POSTERIOR_DB_PATH = get(ENV, "POSTERIOR_DB_PATH", "")
             @test mod isa Model
             @test name(mod) == n
             @test database(mod) == pdb
-            @test info(mod) isa Dict{String}
+            @test info(mod) isa OrderedDict{String}
             ppls = implementation_names(mod)
             @test ppls isa Vector{String}
             @test !isempty(ppls)
@@ -127,9 +128,9 @@ POSTERIOR_DB_PATH = get(ENV, "POSTERIOR_DB_PATH", "")
             @test data isa Dataset
             @test name(data) == n
             @test database(data) == pdb
-            @test info(data) isa Dict{String}
+            @test info(data) isa OrderedDict{String}
             @test isfile(path(data))
-            @test load(data) isa Dict{String}
+            @test load(data) isa OrderedDict{String}
             @test load(data, String) isa String
             @test PosteriorDB.format_json_data(JSON3.read(load(data, String))) == load(data)
         end


### PR DESCRIPTION
Wherever a `Dict` was previously returned, this PR changes that to an `OrderedDict`. This preserves the order information in the JSON files, which is especially nice for reference posterior draws.

This change is breaking.