### PR TITLE
Don't export any methods or types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PosteriorDB"
 uuid = "1c4bc282-d2f5-44f9-b6d1-8c4424a23ad4"
 authors = ["Seth Axen <seth@sethaxen.com> and contributors"]
-version = "0.3.2"
+version = "0.4.0"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -22,78 +22,78 @@ When a database is created with [`database`](@ref), this is automatically used.
 
 ```@repl usage
 using PosteriorDB
-pdb = database()
-path(pdb)
+pdb = PosteriorDB.database()
+PosteriorDB.path(pdb)
 ```
 
 For now, the database is read-only.
 We can list the available posteriors with [`posterior_names`](@ref).
 
 ```@repl usage
-posterior_names(pdb)
+PosteriorDB.posterior_names(pdb)
 ```
 
 We can also list available models with [`model_names`](@ref) and datasets with [`dataset_names`](@ref).
 
 ```@repl usage
-model_names(pdb)
-dataset_names(pdb)
+PosteriorDB.model_names(pdb)
+PosteriorDB.dataset_names(pdb)
 ```
 
 We can fetch a posterior using its name and [`posterior`](@ref).
 
 ```@repl usage
-post = posterior(pdb, "eight_schools-eight_schools_centered")
+post = PosteriorDB.posterior(pdb, "eight_schools-eight_schools_centered")
 ```
 
 Each posterior has a corresponding model and dataset, which can be fetched with [`model`](@ref) and [`dataset`](@ref).
 
 ```@repl usage
-mod = model(post)
-data = dataset(post)
+mod = PosteriorDB.model(post)
+data = PosteriorDB.dataset(post)
 ```
 
 The same model and dataset can be accessed directly from the database.
 
 ```@repl usage
-model(pdb, "eight_schools_centered")
-dataset(pdb, "eight_schools")
+PosteriorDB.model(pdb, "eight_schools_centered")
+PosteriorDB.dataset(pdb, "eight_schools")
 ```
 
 The functions [`database`](@ref), [`name`](@ref), and [`info`](@ref) can be applied to any posterior, model, or dataset.
 
 ```@repl usage
-database(post)
-name(post)
-info(post)
+PosteriorDB.database(post)
+PosteriorDB.name(post)
+PosteriorDB.info(post)
 ```
 
 From the model we can access implementation code and model information.
 
 ```@repl usage
-impl = implementation(mod, "stan")
-path(impl)
-mod_code = load(impl)
+impl = PosteriorDB.implementation(mod, "stan")
+PosteriorDB.path(impl)
+mod_code = PosteriorDB.load(impl)
 println(mod_code)
-info(mod)
+PosteriorDB.info(mod)
 ```
 
 We can access information about the dataset and load it with [`load`](@ref).
 
 ```@repl usage
-info(data)
-path(data)
-load(data)
-load(data, String)
+PosteriorDB.info(data)
+PosteriorDB.path(data)
+PosteriorDB.load(data)
+PosteriorDB.load(data, String)
 ```
 
 Lastly, we can access gold standard posterior draws with [`reference_posterior`](@ref) and [`load`](@ref).
 
 ```@repl usage
-ref = reference_posterior(post)
-info(ref)
-path(ref)
+ref = PosteriorDB.reference_posterior(post)
+PosteriorDB.info(ref)
+PosteriorDB.path(ref)
 using DataFrames
-DataFrame(load(ref))
-load(ref, String)
+DataFrame(PosteriorDB.load(ref))
+PosteriorDB.load(ref, String)
 ```

--- a/src/PosteriorDB.jl
+++ b/src/PosteriorDB.jl
@@ -20,27 +20,4 @@ include("dataset.jl")
 include("posterior.jl")
 include("reference_posterior.jl")
 
-export AbstractImplementation,
-    Dataset,
-    Model,
-    Posterior,
-    PosteriorDatabase,
-    PyMC3ModelImplementation,
-    ReferencePosterior,
-    StanModelImplementation
-export database,
-    dataset,
-    dataset_names,
-    implementation,
-    implementation_names,
-    info,
-    load,
-    model,
-    model_names,
-    name,
-    path,
-    posterior,
-    posterior_names,
-    reference_posterior
-
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,84 +54,87 @@ POSTERIOR_DB_PATH = get(ENV, "POSTERIOR_DB_PATH", "")
     end
 
     if isempty(POSTERIOR_DB_PATH)
-        pdb = database()
+        pdb = PosteriorDB.database()
     else
-        pdb = database(POSTERIOR_DB_PATH)
+        pdb = PosteriorDB.database(POSTERIOR_DB_PATH)
     end
 
     @testset "PosteriorDatabase" begin
-        @test pdb isa PosteriorDatabase
-        @test isdir(path(pdb))
-        VERSION < v"1.3" && @test_throws MethodError database()
+        @test pdb isa PosteriorDB.PosteriorDatabase
+        @test isdir(PosteriorDB.path(pdb))
+        VERSION < v"1.3" && @test_throws MethodError PosteriorDB.database()
     end
 
     @testset "posterior" begin
-        posteriors = posterior_names(pdb)
+        posteriors = PosteriorDB.posterior_names(pdb)
         @test posteriors isa Vector{String}
         @test !isempty(posteriors)
         @testset "$n" for n in posteriors
-            post = posterior(pdb, n)
-            @test post isa Posterior
-            @test name(post) == n
-            @test database(post) == pdb
-            @test info(post) isa Dict{String}
-            mod = model(post)
-            @test mod isa Model
-            @test database(mod) === pdb
-            data = dataset(post)
-            @test data isa Dataset
-            @test database(data) === pdb
-            @test n == "$(name(data))-$(name(mod))" || (n == name(data) == name(mod))
+            post = PosteriorDB.posterior(pdb, n)
+            @test post isa PosteriorDB.Posterior
+            @test PosteriorDB.name(post) == n
+            @test PosteriorDB.database(post) == pdb
+            @test PosteriorDB.info(post) isa Dict{String}
+            mod = PosteriorDB.model(post)
+            @test mod isa PosteriorDB.Model
+            @test PosteriorDB.database(mod) === pdb
+            data = PosteriorDB.dataset(post)
+            @test data isa PosteriorDB.Dataset
+            @test PosteriorDB.database(data) === pdb
+            @test n == "$(PosteriorDB.name(data))-$(PosteriorDB.name(mod))" ||
+                (n == PosteriorDB.name(data) == PosteriorDB.name(mod))
 
-            ref = reference_posterior(post)
-            @test ref isa Union{ReferencePosterior,Nothing}
+            ref = PosteriorDB.reference_posterior(post)
+            @test ref isa Union{PosteriorDB.ReferencePosterior,Nothing}
             if ref !== nothing
-                @test name(ref) isa String
-                @test database(ref) === pdb
-                @test info(ref) isa Dict{String}
-                @test isfile(path(ref))
-                @test load(ref) isa Vector{<:Dict{String}}
-                @test load(ref, String) isa String
+                @test PosteriorDB.name(ref) isa String
+                @test PosteriorDB.database(ref) === pdb
+                @test PosteriorDB.info(ref) isa Dict{String}
+                @test isfile(PosteriorDB.path(ref))
+                @test PosteriorDB.load(ref) isa Vector{<:Dict{String}}
+                @test PosteriorDB.load(ref, String) isa String
             end
         end
     end
 
     @testset "model" begin
-        models = model_names(pdb)
+        models = PosteriorDB.model_names(pdb)
         @test models isa Vector{String}
         @test !isempty(models)
         @testset "$n" for n in models
-            mod = model(pdb, n)
-            @test mod isa Model
-            @test name(mod) == n
-            @test database(mod) == pdb
-            @test info(mod) isa Dict{String}
-            ppls = implementation_names(mod)
+            mod = PosteriorDB.model(pdb, n)
+            @test mod isa PosteriorDB.Model
+            @test PosteriorDB.name(mod) == n
+            @test PosteriorDB.database(mod) == pdb
+            @test PosteriorDB.info(mod) isa Dict{String}
+            ppls = PosteriorDB.implementation_names(mod)
             @test ppls isa Vector{String}
             @test !isempty(ppls)
             @testset "$ppl" for ppl in ppls
-                impl = implementation(mod, ppl)
+                impl = PosteriorDB.implementation(mod, ppl)
                 @test impl isa PosteriorDB.AbstractImplementation
-                @test isfile(path(impl))
-                @test load(impl) isa String
+                @test isfile(PosteriorDB.path(impl))
+                @test PosteriorDB.load(impl) isa String
             end
         end
     end
 
     @testset "dataset" begin
-        datasets = dataset_names(pdb)
+        datasets = PosteriorDB.dataset_names(pdb)
         @test datasets isa Vector{String}
         @test !isempty(datasets)
         @testset "$n" for n in datasets
-            data = dataset(pdb, n)
-            @test data isa Dataset
-            @test name(data) == n
-            @test database(data) == pdb
-            @test info(data) isa Dict{String}
-            @test isfile(path(data))
-            @test load(data) isa Dict{String}
-            @test load(data, String) isa String
-            @test PosteriorDB.format_json_data(JSON3.read(load(data, String))) == load(data)
+            data = PosteriorDB.dataset(pdb, n)
+            @test data isa PosteriorDB.Dataset
+            @test PosteriorDB.name(data) == n
+            @test PosteriorDB.database(data) == pdb
+            @test PosteriorDB.info(data) isa Dict{String}
+            @test isfile(PosteriorDB.path(data))
+            @test PosteriorDB.load(data) isa Dict{String}
+            @test PosteriorDB.load(data, String) isa String
+            @test PosteriorDB.format_json_data(
+                JSON3.read(PosteriorDB.load(data, String))
+            ) == PosteriorDB.load(data)
         end
     end
 end


### PR DESCRIPTION
After using this package a fair bit the issues with name conflicts raised in #5 are quite annoying, so I've opted to remove all exports. The user can use the documented API functions by prefixing with the package name. This is a breaking change.

Fixes #5