### PR TITLE
Fix downgrade CI workflow

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 [compat]
 Aqua = "0.8.9"
 Artifacts = "<0.0.1, 1"
-Compat = "3, 4"
+Compat = "3.46, 4"
 JSON3 = "1"
 OrderedCollections = "1"
 Test = "<0.0.1, 1"

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Compat = "3, 4"
 JSON3 = "1"
 OrderedCollections = "1"
 Test = "<0.0.1, 1"
-ZipFile = "0.8.3, 0.9, 0.10"
+ZipFile = "0.9, 0.10"
 julia = "1.3"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PosteriorDB"
 uuid = "1c4bc282-d2f5-44f9-b6d1-8c4424a23ad4"
 authors = ["Seth Axen <seth@sethaxen.com> and contributors"]
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
-Aqua = "0.4.11, 0.5, 0.6, 0.7, 0.8"
+Aqua = "0.8.9"
 Artifacts = "<0.0.1, 1"
 Compat = "3, 4"
 JSON3 = "1"


### PR DESCRIPTION
On main the CI workflow with downgraded dependencies fails because the General registry was changed so that installing BinaryProvider on Julia v1.11 is no longer allowed. Since ZipFile v0.8.* depended on BinaryProvider, this causes the CI with dependencies downgraded to their lowest compatible version to fail. This PR fixes this by bumping the lowest compatible version of ZipFile to v0.9, which required a few other changes.